### PR TITLE
add sz_auto, and test it locally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,20 +168,16 @@ if(LIBPRESSIO_HAS_BIT_GROOMING)
   target_link_libraries(libpressio PRIVATE bg ZLIB::ZLIB)
 endif()
 
-option(LIBPRESSIO_HAS_SZ_AUTO "build the SZ AUTO plugin" OFF)
+option(LIBPRESSIO_HAS_SZ_AUTO "build the SZauto plugin" OFF)
 if(LIBPRESSIO_HAS_SZ_AUTO)
-  set(LIBPRESSIO_COMPRESSORS "${LIBPRESSIO_COMPRESSORS} SZ_AUTO")
-  get_filename_component(SZ_AUTO_ABS_PATH
-                       "../compressor-install"
-                       ABSOLUTE)
-  find_library (SZ_AUTO_LIB sz_cpp HINTS "${SZ_AUTO_ABS_PATH}/lib")
-  set (SZ_AUTO_INCLUDE "${SZ_AUTO_ABS_PATH}/include/sz_auto")
+  set(LIBPRESSIO_COMPRESSORS "${LIBPRESSIO_COMPRESSORS} SZauto")
+  find_package(szauto REQUIRED)
+  pkg_search_module(ZSTD IMPORTED_TARGET GLOBAL libzstd)
   target_sources(libpressio
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}/src/plugins/compressors/sz_auto_plugin.cc
     )
-  target_include_directories (libpressio PRIVATE ${SZ_AUTO_INCLUDE})
-  target_link_libraries(libpressio PRIVATE ${SZ_AUTO_LIB})
+  target_link_libraries(libpressio PRIVATE szauto)
 endif()
 
 option(LIBPRESSIO_HAS_MGARD "build the MGARD plugin" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,22 @@ if(LIBPRESSIO_HAS_BIT_GROOMING)
   target_link_libraries(libpressio PRIVATE bg ZLIB::ZLIB)
 endif()
 
+option(LIBPRESSIO_HAS_SZ_AUTO "build the SZ AUTO plugin" OFF)
+if(LIBPRESSIO_HAS_SZ_AUTO)
+  set(LIBPRESSIO_COMPRESSORS "${LIBPRESSIO_COMPRESSORS} SZ_AUTO")
+  get_filename_component(SZ_AUTO_ABS_PATH
+                       "../compressor-install"
+                       ABSOLUTE)
+  find_library (SZ_AUTO_LIB sz_cpp HINTS "${SZ_AUTO_ABS_PATH}/lib")
+  set (SZ_AUTO_INCLUDE "${SZ_AUTO_ABS_PATH}/include/sz_auto")
+  target_sources(libpressio
+    PRIVATE
+      ${CMAKE_CURRENT_SOURCE_DIR}/src/plugins/compressors/sz_auto_plugin.cc
+    )
+  target_include_directories (libpressio PRIVATE ${SZ_AUTO_INCLUDE})
+  target_link_libraries(libpressio PRIVATE ${SZ_AUTO_LIB})
+endif()
+
 option(LIBPRESSIO_HAS_MGARD "build the MGARD plugin" OFF)
 if(LIBPRESSIO_HAS_MGARD)
   set(LIBPRESSIO_COMPRESSORS "${LIBPRESSIO_COMPRESSORS} mgard")

--- a/docs/PressioOptions.md
+++ b/docs/PressioOptions.md
@@ -47,6 +47,7 @@ option                  | type        | description
 option                  | type        | description
 ------------------------|-------------|------------
 `sz_auto:error_bounds` | double | the error bounds for the compression
+`sz_auto:sample_ratio` | float | the sample ratio for the compression
 
 
 ### fpzip

--- a/docs/PressioOptions.md
+++ b/docs/PressioOptions.md
@@ -40,6 +40,15 @@ option                  | type        | description
 `digit_rounding:prec` | int32 | the prec parameter of digit rounding (a number between 0 and 64)
 
 
+
+### sz auto
+
+
+option                  | type        | description
+------------------------|-------------|------------
+`sz_auto:error_bounds` | double | the error bounds for the compression
+
+
 ### fpzip
 
 

--- a/src/plugins/compressors/sz_auto_plugin.cc
+++ b/src/plugins/compressors/sz_auto_plugin.cc
@@ -20,6 +20,7 @@ class sz_auto_plugin: public libpressio_compressor_plugin {
     struct pressio_options get_options_impl() const override {
       struct pressio_options options;
       set(options, "sz_auto:error_bounds", error_bounds);
+      set(options, "sz_auto:sample_ratio", sample_ratio);
       return options;
     }
 
@@ -31,6 +32,7 @@ class sz_auto_plugin: public libpressio_compressor_plugin {
 
     int set_options_impl(struct pressio_options const& options) override {
       get(options, "sz_auto:error_bounds", &error_bounds);
+      get(options, "sz_auto:sample_ratio", &sample_ratio);
       return 0;
     }
 
@@ -52,11 +54,11 @@ class sz_auto_plugin: public libpressio_compressor_plugin {
 
       if(type == pressio_float_dtype)
       {
-        compressed_data = sz_compress_autotuning_3d<float>((float*)data, r1, r2, r3, error_bounds, outSize);
+        compressed_data = sz_compress_autotuning_3d<float>((float*)data, r1, r2, r3, error_bounds, outSize, false, false, false, sample_ratio);
       }
       else if(type == pressio_double_dtype)
       {
-        compressed_data = sz_compress_autotuning_3d<double>((double*)data, r1, r2, r3, error_bounds, outSize);
+        compressed_data = sz_compress_autotuning_3d<double>((double*)data, r1, r2, r3, error_bounds, outSize, false, false, false, sample_ratio);
       }
       else
       {
@@ -141,6 +143,7 @@ class sz_auto_plugin: public libpressio_compressor_plugin {
 
     std::string sz_auto_version;
     double error_bounds = 0.1; //params for compressing the sz-auto
+    float sample_ratio = 0.05;
 };
 
 static pressio_register compressor_sz_auto_plugin(compressor_plugins(), "sz_auto", [](){return compat::make_unique<sz_auto_plugin>(); });

--- a/src/plugins/compressors/sz_auto_plugin.cc
+++ b/src/plugins/compressors/sz_auto_plugin.cc
@@ -1,6 +1,7 @@
 #include <sstream>
-#include "sz_auto/sz_autotuning_3d.hpp"
-#include "sz_auto/sz_utils.hpp"
+#include "SZauto/sz_autotuning_3d.hpp"
+#include "SZauto/sz_def.hpp"
+#include "SZauto/sz_utils.hpp"
 #include "libpressio_ext/cpp/data.h" //for access to pressio_data structures
 #include "libpressio_ext/cpp/compressor.h" //for the libpressio_compressor_plugin class
 #include "libpressio_ext/cpp/options.h" // for access to pressio_options
@@ -19,8 +20,8 @@ class sz_auto_plugin: public libpressio_compressor_plugin {
     };
     struct pressio_options get_options_impl() const override {
       struct pressio_options options;
-      set(options, "sz_auto:error_bounds", error_bounds);
-      set(options, "sz_auto:sample_ratio", sample_ratio);
+      set(options, "SZauto:error_bounds", error_bounds);
+      set(options, "SZauto:sample_ratio", sample_ratio);
       return options;
     }
 
@@ -31,8 +32,8 @@ class sz_auto_plugin: public libpressio_compressor_plugin {
     }
 
     int set_options_impl(struct pressio_options const& options) override {
-      get(options, "sz_auto:error_bounds", &error_bounds);
-      get(options, "sz_auto:sample_ratio", &sample_ratio);
+      get(options, "SZauto:error_bounds", &error_bounds);
+      get(options, "SZauto:sample_ratio", &sample_ratio);
       return 0;
     }
 
@@ -49,7 +50,7 @@ class sz_auto_plugin: public libpressio_compressor_plugin {
 
       if(ndims != 3)
       {
-        return set_error(2, "Error: sz_auto only supports 3d compression");
+        return set_error(2, "Error: SZauto only supports 3d compression");
       }
 
       if(type == pressio_float_dtype)
@@ -62,13 +63,13 @@ class sz_auto_plugin: public libpressio_compressor_plugin {
       }
       else
       {
-        return set_error(2, "Error: sz_auto only supports float or double");
+        return set_error(2, "Error: SZauto only supports float or double");
       }
 
       //that means the compressor is complaining about the parameter
       if(compressed_data == NULL)
       {
-        return set_error(2, "Error when sz_auto is compressing the data");
+        return set_error(2, "Error when SZauto is compressing the data");
       }
 
       *output = pressio_data::move(pressio_byte_dtype, compressed_data, 1, &outSize, pressio_data_libc_free_fn, nullptr);
@@ -86,7 +87,7 @@ class sz_auto_plugin: public libpressio_compressor_plugin {
       size_t ndims = pressio_data_num_dimensions(output);
       if(ndims != 3)
       {
-        return set_error(2, "Error: sz_auto only supports 3d decompression");
+        return set_error(2, "Error: SZauto only supports 3d decompression");
       }
 
 
@@ -104,7 +105,7 @@ class sz_auto_plugin: public libpressio_compressor_plugin {
       }
       else
       {
-        return set_error(2, "Error: sz_auto only supports float or double");
+        return set_error(2, "Error: SZauto only supports float or double");
       }
 
 
@@ -113,18 +114,18 @@ class sz_auto_plugin: public libpressio_compressor_plugin {
       }
 
 
-    //the author of sz_auto does not release their version info.
+    //the author of SZauto does not release their version info.
     int major_version() const override {
-      return 0; 
+      return SZAUTO_MAJOR_VERSION; 
     }
     int minor_version() const override {
-      return 0;
+      return SZAUTO_MINOR_VERSION;
     }
     int patch_version() const override {
-      return 0;
+      return SZAUTO_PATCH_VERSION;
     }
     int revision_version () const { 
-      return 1;
+      return SZAUTO_REVISION_VERSION;
     }
 
     const char* version() const override {
@@ -133,7 +134,7 @@ class sz_auto_plugin: public libpressio_compressor_plugin {
 
 
     const char* prefix() const override {
-      return "sz_auto";
+      return "SZauto";
     }
 
     std::shared_ptr<libpressio_compressor_plugin> clone() override {
@@ -146,5 +147,5 @@ class sz_auto_plugin: public libpressio_compressor_plugin {
     float sample_ratio = 0.05;
 };
 
-static pressio_register compressor_sz_auto_plugin(compressor_plugins(), "sz_auto", [](){return compat::make_unique<sz_auto_plugin>(); });
+static pressio_register compressor_sz_auto_plugin(compressor_plugins(), "SZauto", [](){return compat::make_unique<sz_auto_plugin>(); });
 

--- a/src/plugins/compressors/sz_auto_plugin.cc
+++ b/src/plugins/compressors/sz_auto_plugin.cc
@@ -1,0 +1,147 @@
+#include <sstream>
+#include "sz_auto/sz_autotuning_3d.hpp"
+#include "sz_auto/sz_utils.hpp"
+#include "libpressio_ext/cpp/data.h" //for access to pressio_data structures
+#include "libpressio_ext/cpp/compressor.h" //for the libpressio_compressor_plugin class
+#include "libpressio_ext/cpp/options.h" // for access to pressio_options
+#include "libpressio_ext/cpp/pressio.h" //for the plugin registries
+#include "pressio_options.h"
+#include "pressio_data.h"
+#include "pressio_compressor.h"
+#include "std_compat/memory.h"
+
+class sz_auto_plugin: public libpressio_compressor_plugin {
+  public:
+    sz_auto_plugin() {
+      std::stringstream ss;
+      ss << sz_auto_plugin::major_version() << "." << sz_auto_plugin::minor_version() << "." << sz_auto_plugin::patch_version() << "." << sz_auto_plugin::revision_version();
+      sz_auto_version = ss.str();
+    };
+    struct pressio_options get_options_impl() const override {
+      struct pressio_options options;
+      set(options, "sz_auto:error_bounds", error_bounds);
+      return options;
+    }
+
+    struct pressio_options get_configuration_impl() const override {
+      struct pressio_options options;
+      options.set("pressio:thread_safe", static_cast<int>(pressio_thread_safety_multiple));
+      return options;
+    }
+
+    int set_options_impl(struct pressio_options const& options) override {
+      get(options, "sz_auto:error_bounds", &error_bounds);
+      return 0;
+    }
+
+    int compress_impl(const pressio_data *input, struct pressio_data* output) override {
+      enum pressio_dtype type = pressio_data_dtype(input);
+      unsigned long outSize;
+      void* data = pressio_data_ptr(input, nullptr);
+      unsigned char* compressed_data;
+
+      size_t ndims = pressio_data_num_dimensions(input);
+      size_t r1 = pressio_data_get_dimension(input, 0);
+      size_t r2 = pressio_data_get_dimension(input, 1);
+      size_t r3 = pressio_data_get_dimension(input, 2);
+
+      if(ndims != 3)
+      {
+        return set_error(2, "Error: sz_auto only supports 3d compression");
+      }
+
+      if(type == pressio_float_dtype)
+      {
+        compressed_data = sz_compress_autotuning_3d<float>((float*)data, r1, r2, r3, error_bounds, outSize);
+      }
+      else if(type == pressio_double_dtype)
+      {
+        compressed_data = sz_compress_autotuning_3d<double>((double*)data, r1, r2, r3, error_bounds, outSize);
+      }
+      else
+      {
+        return set_error(2, "Error: sz_auto only supports float or double");
+      }
+
+      //that means the compressor is complaining about the parameter
+      if(compressed_data == NULL)
+      {
+        return set_error(2, "Error when sz_auto is compressing the data");
+      }
+
+      *output = pressio_data::move(pressio_byte_dtype, compressed_data, 1, &outSize, pressio_data_libc_free_fn, nullptr);
+      return 0;
+    }
+
+    int decompress_impl(const pressio_data *input, struct pressio_data* output) override {
+      enum pressio_dtype dtype = pressio_data_dtype(output);
+
+      size_t r[] = {
+        pressio_data_get_dimension(output, 0),
+        pressio_data_get_dimension(output, 1),
+        pressio_data_get_dimension(output, 2),
+      };
+      size_t ndims = pressio_data_num_dimensions(output);
+      if(ndims != 3)
+      {
+        return set_error(2, "Error: sz_auto only supports 3d decompression");
+      }
+
+
+      size_t compressed_size;
+      void* compressedBytes = pressio_data_ptr(input, &compressed_size);
+
+      void* decompressed_data;
+      if(dtype == pressio_float_dtype)
+      {
+        decompressed_data = sz_decompress_autotuning_3d<float>((unsigned char*)compressedBytes, compressed_size, r[0], r[1], r[2]);
+      }
+      else if(dtype == pressio_double_dtype)
+      {
+        decompressed_data = sz_decompress_autotuning_3d<double>((unsigned char*)compressedBytes, compressed_size, r[0], r[1], r[2]);
+      }
+      else
+      {
+        return set_error(2, "Error: sz_auto only supports float or double");
+      }
+
+
+      *output = pressio_data::move(dtype, decompressed_data, ndims, r, pressio_data_libc_free_fn, nullptr);
+      return 0;
+      }
+
+
+    //the author of sz_auto does not release their version info.
+    int major_version() const override {
+      return 0; 
+    }
+    int minor_version() const override {
+      return 0;
+    }
+    int patch_version() const override {
+      return 0;
+    }
+    int revision_version () const { 
+      return 1;
+    }
+
+    const char* version() const override {
+      return sz_auto_version.c_str(); 
+    }
+
+
+    const char* prefix() const override {
+      return "sz_auto";
+    }
+
+    std::shared_ptr<libpressio_compressor_plugin> clone() override {
+      return compat::make_unique<sz_auto_plugin>(*this);
+    }
+  private:
+
+    std::string sz_auto_version;
+    double error_bounds = 0.1; //params for compressing the sz-auto
+};
+
+static pressio_register compressor_sz_auto_plugin(compressor_plugins(), "sz_auto", [](){return compat::make_unique<sz_auto_plugin>(); });
+


### PR DESCRIPTION
Hello Robert,
I have added sz_auto plugin to libpressio. I have tested locally, which seems fine. 
However, since I did not have control over sz_auto repo, there are some issues:
1. The version info in the plugin is not correct, since I don't have access to their version. I will ask Di to get their version info. 
2. In their of CMakeLists, they did not export the whole project. Therefore, I cannot use find_package() to link the library. I can only link it by hand. I will also ask Di to maybe update their CMakeLists. 