### PR TITLE
revert cusz-plugin initializer for better compiler compat: lower cpp-std requirement

### DIFF
--- a/src/plugins/compressors/cusz.cc
+++ b/src/plugins/compressors/cusz.cc
@@ -303,28 +303,27 @@ public:
 
     pszheader header;
     pszframe* work = new pszframe{
-        .predictor = pszpredictor{.type = to_cusz_predictor_type(predictor)},
-        .quantizer = pszquantizer{.radius = radius},
-        .hfcoder = pszhfrc{
-            .book = to_bookstyle(bookstyle),
-            .style = to_huffman_style(huffman_coding_style),
-            .booklen = booklen,
-            .coarse_pardeg = coarse_pardeg 
+        pszpredictor{to_cusz_predictor_type(predictor)},
+        pszquantizer{radius},
+        pszhfrc{
+            to_bookstyle(bookstyle),
+            to_huffman_style(huffman_coding_style),
+            booklen,
+            coarse_pardeg 
         },
-        .max_outlier_percent = max_outlier_percent};
+        max_outlier_percent};
     pszcompressor* comp = psz_create(work, to_cuszdtype(input->dtype()));
-    auto ctx = std::make_unique<pszctx>(pszctx{
-        .device = to_device(device),
-        .pred_type = to_cusz_predictor_type(predictor),
-        .dbgstr_pred = "",
-        .demodata_name = "",
-        .infile = "",
-        .original_file = "",
-        .opath = "",
-        .mode = to_cuszmode(eb_mode),
-        .eb = err_bnd,
+    auto ctx = std::make_unique<pszctx>(pszctx{});
+    ctx->device = to_device(device);
+    ctx->pred_type = to_cusz_predictor_type(predictor);
+    // ctx->dbgstr_pred = "";
+    // ctx->demodata_name = "";
+    // ctx->infile = "";
+    // ctx->original_file = "";
+    // ctx->opath = "";
+    ctx->mode = to_cuszmode(eb_mode);
+    ctx->eb = err_bnd;
 
-    });
     pszlen uncomp_len = pszlen{{dims[0]}, {dims[1]}, {dims[2]}, {dims[3]}};
     psz::TimeRecord compress_timerecord;
     psz_compress_init(comp, uncomp_len, ctx.get());


### PR DESCRIPTION
- issue to address: designated initializers were used for specific cusz data structures for configuration, and they required very new cpp-std (i.e., cpp20), blocking the build process.
- how it is resolved: aggregate initializers mixed with the direct variable assignments are used instead.
- Also note that `char *`-type variables were omitted (`""` instances were previously used); this pull request is intended for a quick fix within `libpressio` codebase.
- Please refer to https://github.com/szcompressor/cuSZ/commit/706af14d7ff6a743243bf5698db3c99ad500a780 (also marked as [cusz v0.9-rc2](url)) for a `cusz` reversion with the same change in initializers in a demo.