### PR TITLE
update cusz-plugin

### DIFF
--- a/src/plugins/compressors/cusz.cc
+++ b/src/plugins/compressors/cusz.cc
@@ -16,8 +16,8 @@
 namespace libpressio { namespace cusz_ns {
 
     const std::map<std::string, decltype(Rel)> bounds {
-        {"rel",Rel},
-            {"rel",Abs},
+        {"abs", Abs},
+            {"rel", Rel},
     };
     const std::map<std::string, decltype(NVGPU)> devices {
         {"cuda",NVGPU},
@@ -25,24 +25,13 @@ namespace libpressio { namespace cusz_ns {
             {"intel",INTELGPU},
             {"cpu",CPU},
     };
-    const std::map<std::string, decltype(Canonical)> bookstyles {
-        { "canonical", Canonical},
-            { "sword", Sword},
-            { "mword", Mword}
-    };
     const std::map<std::string, decltype(Abs)> cuszmode {
         {"abs", Abs},
             {"rel", Rel},
     };
     const std::map<std::string, decltype(Lorenzo)> predictors {
         {"lorenzo", Lorenzo},
-            {"lorenzoi", Lorenzo},
-            {"lorenzo0", Lorenzo},
             {"spline", Spline},
-    };
-    const std::map<std::string, decltype(Fine)> huffman_styles {
-        {"coarse",Coarse},
-            {"fine",Fine},
     };
 
 template <class T>
@@ -75,11 +64,9 @@ public:
     set(options, "cusz:bound", err_bnd);
     set(options, "cusz:coarse_pardeg", coarse_pardeg);
     set(options, "cusz:booklen", booklen);
-    set(options, "cusz:bookstyle", bookstyle);
     set(options, "cusz:radius", radius);
     set(options, "cusz:max_outlier_percent", max_outlier_percent);
     set(options, "cusz:device", device);
-    set(options, "cusz:huffman_coding_style", huffman_coding_style);
     set(options, "cusz:predictor", predictor);
 
     return options;
@@ -90,17 +77,15 @@ public:
     struct pressio_options options;
     set(options, "cusz:mode_str", to_keys(bounds));
     set(options, "cusz:device", to_keys(devices));
-    set(options, "cusz:huffman_coding_style", to_keys(huffman_styles));
     set(options, "cusz:predictor", to_keys(predictors));
-    set(options, "cusz:bookstyle", to_keys(bookstyles));
     set(options, "pressio:thread_safe", pressio_thread_safety_multiple);
     set(options, "pressio:stability", "experimental");
     
     std::vector<pressio_configurable const*> invalidation_children {}; 
     set(options, "pressio:highlevel", get_accumulate_configuration("pressio:highlevel", invalidation_children, std::vector<std::string>{"pressio:abs", "pressio:rel"}));
-    std::vector<std::string> error_invalidations {"cusz:mode_str", "cusz:bound",  "cusz:radius", "cusz:max_outlier_percent", "cusz:huffman_coding_style", "cusz:predictor", "pressio:abs", "pressio:rel"}; 
-    std::vector<std::string> invalidations {"cusz:mode_str", "cusz:bound", "cusz:coarse_pardeg", "cusz:booklen", "cusz:bookstyle", "cusz:radius", "cusz:max_outlier_percent", "cusz:huffman_coding_style", "cusz:predictor", "pressio:abs", "pressio:rel"}; 
-    std::vector<std::string> runtime_invalidations {"cusz:mode_str", "cusz:bound", "cusz:coarse_pardeg", "cusz:booklen", "cusz:bookstyle", "cusz:radius", "cusz:max_outlier_percent", "cusz:device", "cusz:huffman_coding_style", "cusz:predictor", "pressio:abs", "pressio:rel"}; 
+    std::vector<std::string> error_invalidations {"cusz:mode_str", "cusz:bound",  "cusz:radius", "cusz:max_outlier_percent", "cusz:predictor", "pressio:abs", "pressio:rel"}; 
+    std::vector<std::string> invalidations {"cusz:mode_str", "cusz:bound", "cusz:coarse_pardeg", "cusz:booklen", "cusz:radius", "cusz:max_outlier_percent", "cusz:predictor", "pressio:abs", "pressio:rel"}; 
+    std::vector<std::string> runtime_invalidations {"cusz:mode_str", "cusz:bound", "cusz:coarse_pardeg", "cusz:booklen", "cusz:radius", "cusz:max_outlier_percent", "cusz:device", "cusz:predictor", "pressio:abs", "pressio:rel"}; 
     
     set(options, "predictors:error_dependent", get_accumulate_configuration("predictors:error_dependent", invalidation_children, error_invalidations));
     set(options, "predictors:error_agnostic", get_accumulate_configuration("predictors:error_agnostic", invalidation_children, invalidations));
@@ -117,11 +102,9 @@ public:
     set(options, "cusz:bound", "bound of the error bound");
     set(options, "cusz:coarse_pardeg", "paralellism degree for the huffman encoding stage");
     set(options, "cusz:booklen", "huffman encoding booklength");
-    set(options, "cusz:bookstyle", "huffman encoding bookstyle");
     set(options, "cusz:radius", "quantizer radius");
     set(options, "cusz:max_outlier_percent", "max outlier percent");
     set(options, "cusz:device", "execucution device");
-    set(options, "cusz:huffman_coding_style", "huffman coding style");
     set(options, "cusz:predictor", "predictor style");
     return options;
   }
@@ -139,11 +122,9 @@ public:
     get(options, "cusz:bound", &err_bnd);
     get(options, "cusz:coarse_pardeg", &coarse_pardeg);
     get(options, "cusz:booklen", &booklen);
-    get(options, "cusz:bookstyle", &bookstyle);
     get(options, "cusz:radius", &radius);
     get(options, "cusz:max_outlier_percent", &max_outlier_percent);
     get(options, "cusz:device", &device);
-    get(options, "cusz:huffman_coding_style", &huffman_coding_style);
     get(options, "cusz:predictor", &predictor);
 
     return 0;
@@ -187,13 +168,6 @@ public:
         return predictors.at(s);
       } catch(std::out_of_range const& ex) {
         throw std::domain_error("unsupported predictor_type: " + s);
-      }
-  }
-  psz_hfpartype to_huffman_style(std::string const& s) {
-      try {
-        return huffman_styles.at(s);
-      } catch(std::out_of_range const& ex) {
-        throw std::domain_error("unsupported huffman style: " + s);
       }
   }
 
@@ -263,13 +237,6 @@ public:
         throw std::runtime_error("unsupported mode " + mode);
       }
   }
-  auto to_bookstyle(std::string const& s) {
-      try {
-        return bookstyles.at(s);
-      } catch(std::out_of_range const& ex) {
-        throw std::runtime_error("unsupported bookstyle " + s);
-      }
-  }
   auto to_device(std::string const& s) {
       try {
         return devices.at(s);
@@ -301,30 +268,15 @@ public:
         lp_check_cuda_error(cudaMemcpyAsync(d_uncomp, input->data(), input->size_in_bytes(), cudaMemcpyHostToDevice, stream));
     }
 
-    pszheader header;
-    pszframe* work = new pszframe{
-        pszpredictor{to_cusz_predictor_type(predictor)},
-        pszquantizer{radius},
-        pszhfrc{
-            to_bookstyle(bookstyle),
-            to_huffman_style(huffman_coding_style),
-            booklen,
-            coarse_pardeg 
-        },
-        max_outlier_percent};
-    pszcompressor* comp = psz_create(work, to_cuszdtype(input->dtype()));
-    auto ctx = std::make_unique<pszctx>(pszctx{});
-    ctx->device = to_device(device);
-    ctx->pred_type = to_cusz_predictor_type(predictor);
-    ctx->mode = to_cuszmode(eb_mode);
-    ctx->eb = err_bnd;
-
-    pszlen uncomp_len = pszlen{{dims[0]}, {dims[1]}, {dims[2]}, {dims[3]}};
-    psz::TimeRecord compress_timerecord;
-    psz_compress_init(comp, uncomp_len, ctx.get());
+    psz_header header;
+    void* compress_timerecord;
+    psz_len3 uncomp_len = psz_len3{{dims[0]}, {dims[1]}, {dims[2]}};
+    psz_compressor* comp = psz_create(to_cuszdtype(input->dtype()), uncomp_len, to_cusz_predictor_type(predictor),
+        radius, Huffman); // codectype Huffman is hardcoded. (v0.10rc)
     psz_compress(
-        comp, d_uncomp, uncomp_len, &ptr_compressed, &compressed_len, &header,
-        (void*)&compress_timerecord, stream);
+        comp, d_uncomp, uncomp_len, err_bnd, to_cuszmode(eb_mode), 
+        &ptr_compressed, &compressed_len, &header, compress_timerecord, stream);
+
 
     if(isDevicePtr(input->data())) {
         if(output->has_data() && isDevicePtr(output->data()) && compressed_len <= output->capacity_in_bytes()) {
@@ -375,7 +327,6 @@ public:
         }
     }
 
-
     //call when we are done
     psz_release(comp);
     cudaStreamDestroy(stream);
@@ -391,7 +342,7 @@ public:
     T *d_decomp;
     lp_check_cuda_error(cudaMallocAsync(&d_decomp, output->size_in_bytes(), stream));
     uint8_t* ptr_compressed;
-    pszheader header;
+    psz_header header;
     size_t compressed_len = input->size_in_bytes() - sizeof(header);
     if(isDevicePtr(input->data())) {
         lp_check_cuda_error(cudaMemcpyAsync(&header, input->data(), sizeof(header), cudaMemcpyDeviceToHost, stream));
@@ -403,23 +354,10 @@ public:
         lp_check_cuda_error(cudaMemcpyAsync(ptr_compressed, (uint8_t*)input->data()+sizeof(header), compressed_len, cudaMemcpyHostToDevice, stream));
     }
 
-    psz::TimeRecord decompress_timerecord;
-    pszlen decomp_len = pszlen{{dims[0]}, {dims[1]}, {dims[2]}, {dims[3]}};  // x, y, z, w
-    auto work = std::make_unique<pszframe>(pszframe{
-        .predictor = pszpredictor{.type = to_cusz_predictor_type(predictor)},
-        .quantizer = pszquantizer{.radius = radius},
-        .hfcoder = pszhfrc{
-            .book = to_bookstyle(bookstyle),
-            .style = to_huffman_style(huffman_coding_style),
-            .booklen = booklen,
-            .coarse_pardeg = coarse_pardeg 
-        },
-        .max_outlier_percent = max_outlier_percent});
-    pszcompressor* comp = psz_create(work.get(), to_cuszdtype(output->dtype()));
-    psz_decompress_init(comp, &header);
-    psz_decompress(
-        comp, ptr_compressed, compressed_len, d_decomp, decomp_len,
-        (void*)&decompress_timerecord, stream);
+    void* decompress_timerecord;
+    psz_len3 decomp_len = psz_len3{{dims[0]}, {dims[1]}, {dims[2]}};  // x, y, z
+    psz_compressor* comp = psz_create_from_header(&header);
+    psz_decompress(comp, ptr_compressed, compressed_len, d_decomp, decomp_len, decompress_timerecord, stream);
 
     if(isDevicePtr(input->data())) {
         if(output->has_data() && isDevicePtr(output->data()) && compressed_len <= output->capacity_in_bytes()) {
@@ -469,12 +407,9 @@ public:
   }
 
 
-
   double err_bnd = 1e-5;
   std::string eb_mode = "abs";
   std::string predictor = "lorenzo";
-  std::string huffman_coding_style = "coarse";
-  std::string bookstyle = "canonical";
   std::string device = "cuda";
   float max_outlier_percent = 10.0;
   int32_t radius = 512;

--- a/src/plugins/compressors/cusz.cc
+++ b/src/plugins/compressors/cusz.cc
@@ -34,6 +34,46 @@ namespace libpressio { namespace cusz_ns {
             {"spline", Spline},
     };
 
+    struct stream_helper {
+        stream_helper() {
+            cudaStreamCreate(&stream);
+        }
+        ~stream_helper() {
+            if(cleanup) {
+                cudaStreamDestroy(stream);
+            }
+        }
+        stream_helper(stream_helper&) {
+            cudaStreamCreate(&stream);
+        }
+        stream_helper& operator=(stream_helper& rhs) {
+            if(this == &rhs) return *this;
+            cudaStreamCreate(&stream);
+            return *this;
+        }
+        stream_helper& operator=(stream_helper&& rhs) {
+            if(this == &rhs) return *this;
+            rhs.cleanup=false;
+            stream = rhs.stream;
+            return *this;
+        }
+        void reset(cudaStream_t& new_stream) {
+            cudaStreamDestroy(stream);
+            stream = new_stream;
+        }
+        stream_helper(stream_helper&& rhs): stream(rhs.stream) {
+            rhs.cleanup=false;
+        }
+        cudaStream_t& operator* (){
+            return stream;
+        }
+        cudaStream_t* get() const {
+            return const_cast<cudaStream_t*>(&stream);
+        }
+        cudaStream_t stream;
+        bool cleanup = true;
+    };
+
 template <class T>
 std::vector<std::string> to_keys(std::map<std::string, T> const& map) {
     std::set<std::string> s;
@@ -68,6 +108,8 @@ public:
     set(options, "cusz:max_outlier_percent", max_outlier_percent);
     set(options, "cusz:device", device);
     set(options, "cusz:predictor", predictor);
+    set(options, "pressio:cuda_stream", static_cast<void*>(stream.get()));
+    set(options, "cusz:cuda_stream", static_cast<void*>(stream.get()));
 
     return options;
   }
@@ -126,6 +168,17 @@ public:
     get(options, "cusz:max_outlier_percent", &max_outlier_percent);
     get(options, "cusz:device", &device);
     get(options, "cusz:predictor", &predictor);
+  
+    // arbitrary stream
+    void* void_stream;
+    if(get(options, "pressio:cuda_stream", &void_stream) == pressio_options_key_set) {
+        cudaStream_t* cuda_stream = static_cast<cudaStream_t*>(void_stream);
+        stream.reset(*cuda_stream);
+    }
+    if(get(options, "cusz:cuda_stream", &void_stream) == pressio_options_key_set) {
+        cudaStream_t* cuda_stream = static_cast<cudaStream_t*>(void_stream);
+        stream.reset(*cuda_stream);
+    }
 
     return 0;
   }
@@ -252,8 +305,6 @@ public:
 
   template<class T>
   int compress_typed(pressio_data const* input, pressio_data* output) {
-    cudaStream_t stream;
-    lp_check_cuda_error(cudaStreamCreate(&stream));
 
     auto const dims = input->normalized_dims(4, 1);
 
@@ -264,8 +315,8 @@ public:
     if(isDevicePtr(input->data())) {
         d_uncomp = (T*)input->data();
     } else {
-        lp_check_cuda_error(cudaMallocAsync(&d_uncomp, input->size_in_bytes(), stream));
-        lp_check_cuda_error(cudaMemcpyAsync(d_uncomp, input->data(), input->size_in_bytes(), cudaMemcpyHostToDevice, stream));
+        lp_check_cuda_error(cudaMallocAsync(&d_uncomp, input->size_in_bytes(), *stream.get()));
+        lp_check_cuda_error(cudaMemcpyAsync(d_uncomp, input->data(), input->size_in_bytes(), cudaMemcpyHostToDevice, *stream.get()));
     }
 
     psz_header header;
@@ -275,7 +326,7 @@ public:
         radius, Huffman); // codectype Huffman is hardcoded. (v0.10rc)
     psz_compress(
         comp, d_uncomp, uncomp_len, err_bnd, to_cuszmode(eb_mode), 
-        &ptr_compressed, &compressed_len, &header, compress_timerecord, stream);
+        &ptr_compressed, &compressed_len, &header, compress_timerecord, *stream.get());
 
 
     if(isDevicePtr(input->data())) {
@@ -284,23 +335,23 @@ public:
             //compressed data needs to be copied before the compressor is destructed
             lp_check_cuda_error(cudaMemcpyAsync(
                     (uint8_t*)output->data(), &header, sizeof(header),
-                    cudaMemcpyDeviceToDevice, stream));
+                    cudaMemcpyDeviceToDevice, *stream.get()));
             lp_check_cuda_error(cudaMemcpyAsync(
                     (uint8_t*)output->data()+sizeof(header), ptr_compressed, compressed_len,
-                    cudaMemcpyDeviceToDevice, stream));
+                    cudaMemcpyDeviceToDevice, *stream.get()));
             output->set_dimensions({compressed_len + sizeof(header)});
             output->set_dtype(pressio_byte_dtype);
-            lp_check_cuda_error(cudaStreamSynchronize(stream));
+            lp_check_cuda_error(cudaStreamSynchronize(*stream.get()));
 
         } else {
-            lp_check_cuda_error(cudaMallocAsync(&compressed_buf, compressed_len+sizeof(header), stream));
+            lp_check_cuda_error(cudaMallocAsync(&compressed_buf, compressed_len+sizeof(header), *stream.get()));
             lp_check_cuda_error(cudaMemcpyAsync(
                     (uint8_t*)output->data(), &header, sizeof(header),
-                    cudaMemcpyDeviceToDevice, stream));
+                    cudaMemcpyDeviceToDevice, *stream.get()));
             lp_check_cuda_error(cudaMemcpyAsync(
                   compressed_buf+sizeof(header), ptr_compressed, compressed_len,
-                  cudaMemcpyDeviceToDevice, stream));
-            lp_check_cuda_error(cudaStreamSynchronize(stream));
+                  cudaMemcpyDeviceToDevice, *stream.get()));
+            lp_check_cuda_error(cudaStreamSynchronize(*stream.get()));
             *output = pressio_data::move(
                     pressio_byte_dtype, compressed_buf,
                     {compressed_len}, [](void* data, void*){ cudaFree(data);}, nullptr
@@ -313,62 +364,60 @@ public:
             memcpy(output->data(), &header, sizeof(header));
             lp_check_cuda_error(cudaMemcpyAsync(
                   (uint8_t*)output->data() + sizeof(header), ptr_compressed, compressed_len,
-                  cudaMemcpyDeviceToHost, stream));
+                  cudaMemcpyDeviceToHost, *stream.get()));
             output->set_dimensions({compressed_len+sizeof(header)});
             output->set_dtype(pressio_byte_dtype);
-            lp_check_cuda_error(cudaStreamSynchronize(stream));
+            lp_check_cuda_error(cudaStreamSynchronize(*stream.get()));
         } else {
             *output = pressio_data::owning(pressio_byte_dtype, {sizeof(header)+compressed_len});
             memcpy(output->data(), &header, sizeof(header));
             lp_check_cuda_error(cudaMemcpyAsync(
                   (uint8_t*)output->data()+sizeof(header), ptr_compressed, compressed_len,
-                  cudaMemcpyDeviceToHost, stream));
-            lp_check_cuda_error(cudaStreamSynchronize(stream));
+                  cudaMemcpyDeviceToHost, *stream.get()));
+            lp_check_cuda_error(cudaStreamSynchronize(*stream.get()));
         }
     }
 
     //call when we are done
     psz_release(comp);
-    cudaStreamDestroy(stream);
+    // cudaStreamDestroy(stream);
 
     return 0;
   }
 
   template<class T>
   int decompress_typed(pressio_data const* input, pressio_data* output) {
-    cudaStream_t stream;
-    cudaStreamCreate(&stream);
     auto const dims = output->normalized_dims(4, 1);
     T *d_decomp;
-    lp_check_cuda_error(cudaMallocAsync(&d_decomp, output->size_in_bytes(), stream));
+    lp_check_cuda_error(cudaMallocAsync(&d_decomp, output->size_in_bytes(), *stream.get()));
     uint8_t* ptr_compressed;
     psz_header header;
     size_t compressed_len = input->size_in_bytes() - sizeof(header);
     if(isDevicePtr(input->data())) {
-        lp_check_cuda_error(cudaMemcpyAsync(&header, input->data(), sizeof(header), cudaMemcpyDeviceToHost, stream));
-        lp_check_cuda_error(cudaStreamSynchronize(stream));
+        lp_check_cuda_error(cudaMemcpyAsync(&header, input->data(), sizeof(header), cudaMemcpyDeviceToHost, *stream.get()));
+        lp_check_cuda_error(cudaStreamSynchronize(*stream.get()));
         ptr_compressed = (uint8_t*)input->data()+sizeof(header);
     } else {
         memcpy(&header, input->data(), sizeof(header));
-        lp_check_cuda_error(cudaMallocAsync(&ptr_compressed, compressed_len, stream));
-        lp_check_cuda_error(cudaMemcpyAsync(ptr_compressed, (uint8_t*)input->data()+sizeof(header), compressed_len, cudaMemcpyHostToDevice, stream));
+        lp_check_cuda_error(cudaMallocAsync(&ptr_compressed, compressed_len, *stream.get()));
+        lp_check_cuda_error(cudaMemcpyAsync(ptr_compressed, (uint8_t*)input->data()+sizeof(header), compressed_len, cudaMemcpyHostToDevice, *stream.get()));
     }
 
     void* decompress_timerecord;
     psz_len3 decomp_len = psz_len3{{dims[0]}, {dims[1]}, {dims[2]}};  // x, y, z
     psz_compressor* comp = psz_create_from_header(&header);
-    psz_decompress(comp, ptr_compressed, compressed_len, d_decomp, decomp_len, decompress_timerecord, stream);
+    psz_decompress(comp, ptr_compressed, compressed_len, d_decomp, decomp_len, decompress_timerecord, *stream.get());
 
     if(isDevicePtr(input->data())) {
         if(output->has_data() && isDevicePtr(output->data()) && compressed_len <= output->capacity_in_bytes()) {
             //copy to existing device ptr
-            lp_check_cuda_error(cudaMemcpyAsync(output->data(), d_decomp, output->size_in_bytes(), cudaMemcpyDeviceToDevice, stream));
+            lp_check_cuda_error(cudaMemcpyAsync(output->data(), d_decomp, output->size_in_bytes(), cudaMemcpyDeviceToDevice, *stream.get()));
         } else {
             //copy to new device ptr
             T* buf_uncompressed;
-            lp_check_cuda_error(cudaMallocAsync(&buf_uncompressed, output->size_in_bytes(), stream));
-            lp_check_cuda_error(cudaMemcpyAsync(buf_uncompressed, d_decomp, output->size_in_bytes(), cudaMemcpyDeviceToDevice, stream));
-            lp_check_cuda_error(cudaStreamSynchronize(stream));
+            lp_check_cuda_error(cudaMallocAsync(&buf_uncompressed, output->size_in_bytes(), *stream.get()));
+            lp_check_cuda_error(cudaMemcpyAsync(buf_uncompressed, d_decomp, output->size_in_bytes(), cudaMemcpyDeviceToDevice, *stream.get()));
+            lp_check_cuda_error(cudaStreamSynchronize(*stream.get()));
             *output = pressio_data::move(output->dtype(),
                     buf_uncompressed, output->dimensions(),
                     [](void* data, void*){ cudaFree(data);}, nullptr
@@ -377,12 +426,12 @@ public:
     } else {
         //copy to host pointer
         if(output->has_data()) {
-            lp_check_cuda_error(cudaMemcpyAsync(output->data(), d_decomp, output->size_in_bytes(), cudaMemcpyDeviceToHost, stream));
+            lp_check_cuda_error(cudaMemcpyAsync(output->data(), d_decomp, output->size_in_bytes(), cudaMemcpyDeviceToHost, *stream.get()));
         } else {
             *output = pressio_data::owning(output->dtype(), output->dimensions());
-            lp_check_cuda_error(cudaMemcpyAsync(output->data(), d_decomp, output->size_in_bytes(), cudaMemcpyDeviceToHost, stream));
+            lp_check_cuda_error(cudaMemcpyAsync(output->data(), d_decomp, output->size_in_bytes(), cudaMemcpyDeviceToHost, *stream.get()));
         }
-        lp_check_cuda_error(cudaStreamSynchronize(stream));
+        lp_check_cuda_error(cudaStreamSynchronize(*stream.get()));
         lp_check_cuda_error(cudaFree(ptr_compressed));
     }
     psz_release(comp);
@@ -406,6 +455,7 @@ public:
     return compat::make_unique<cusz_compressor_plugin>(*this);
   }
 
+  stream_helper stream; 
 
   double err_bnd = 1e-5;
   std::string eb_mode = "abs";


### PR DESCRIPTION
plugin updates

- simplified compressor setup (RAII)
- update type names
- remove unused enum/types
- [caveat] hardcode `Huffman` as `codectype`

cusz updates

- corresponding to v0.10-rc1 [v0.10-rc1](https://github.com/szcompressor/cuSZ/releases/tag/v0.10-rc1) or https://github.com/szcompressor/cuSZ/commit/7ef098b1ed17a3b64697597bef01d161e3524ad4
- [fix] passing predictor type
- [fix] passing compression mode (Rel/Abs)
- [fix] memory issue in spline buf